### PR TITLE
Support renaming properties in `in` expressions 

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,6 +78,33 @@ module.exports = function ({ types: t }, options = {}) {
           path.skip();
         },
       },
+      BinaryExpression: {
+        exit(path) {
+          const node = path.node;
+          if (node.operator !== "in") {
+            return;
+          }
+
+          const left = node.left;
+          if (!t.isStringLiteral(left)) {
+            return;
+          }
+
+          const oldName = left.value;
+          const newName = nameMap.get(oldName);
+          if (newName === undefined) {
+            return;
+          }
+
+          const replacedNode = t.binaryExpression(
+            "in",
+            t.stringLiteral(newName),
+            node.right
+          );
+          path.replaceWith(replacedNode);
+          path.skip();
+        },
+      },
     },
   };
 };

--- a/index.js
+++ b/index.js
@@ -1,3 +1,20 @@
+/** Check if node is a template literal with no expressions (e.g., `foo`) */
+function isConstantTemplateLiteral(t, node) {
+  return (
+    t.isTemplateLiteral(node) &&
+    node.expressions.length === 0 &&
+    node.quasis.length === 1
+  );
+}
+
+/** Create a template literal node with no expressions (e.g., `foo`) */
+function constantTemplateLiteral(t, value) {
+  return t.templateLiteral(
+    [t.templateElement({ raw: value, cooked: value }, true)],
+    []
+  );
+}
+
 module.exports = function ({ types: t }, options = {}) {
   const rename = options.rename || {};
 
@@ -90,16 +107,9 @@ module.exports = function ({ types: t }, options = {}) {
 
           if (t.isStringLiteral(node.left)) {
             oldName = node.left.value;
-          } else if (t.isTemplateLiteral(node.left)) {
-            if (
-              node.left.expressions.length === 0 &&
-              node.left.quasis.length === 1
-            ) {
-              oldName = node.left.quasis[0].value.cooked;
-              isTemplateLiteral = true;
-            } else {
-              return;
-            }
+          } else if (isConstantTemplateLiteral(t, node.left)) {
+            oldName = node.left.quasis[0].value.cooked;
+            isTemplateLiteral = true;
           } else {
             return;
           }
@@ -110,10 +120,7 @@ module.exports = function ({ types: t }, options = {}) {
           }
 
           const newNode = isTemplateLiteral
-            ? t.templateLiteral(
-                [t.templateElement({ raw: newName, cooked: newName }, true)],
-                []
-              )
+            ? constantTemplateLiteral(t, newName)
             : t.stringLiteral(newName);
 
           const replacedNode = t.binaryExpression("in", newNode, node.right);

--- a/index.js
+++ b/index.js
@@ -85,22 +85,38 @@ module.exports = function ({ types: t }, options = {}) {
             return;
           }
 
-          const left = node.left;
-          if (!t.isStringLiteral(left)) {
+          let oldName;
+          let isTemplateLiteral = false;
+
+          if (t.isStringLiteral(node.left)) {
+            oldName = node.left.value;
+          } else if (t.isTemplateLiteral(node.left)) {
+            if (
+              node.left.expressions.length === 0 &&
+              node.left.quasis.length === 1
+            ) {
+              oldName = node.left.quasis[0].value.cooked;
+              isTemplateLiteral = true;
+            } else {
+              return;
+            }
+          } else {
             return;
           }
 
-          const oldName = left.value;
           const newName = nameMap.get(oldName);
           if (newName === undefined) {
             return;
           }
 
-          const replacedNode = t.binaryExpression(
-            "in",
-            t.stringLiteral(newName),
-            node.right
-          );
+          const newNode = isTemplateLiteral
+            ? t.templateLiteral(
+                [t.templateElement({ raw: newName, cooked: newName }, true)],
+                []
+              )
+            : t.stringLiteral(newName);
+
+          const replacedNode = t.binaryExpression("in", newNode, node.right);
           path.replaceWith(replacedNode);
           path.skip();
         },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -194,4 +194,50 @@ describe("babel-plugin-transform-rename-properties", () => {
       });
     });
   });
+
+  describe("for `in` operator", () => {
+    it("renames string literal property", () => {
+      compare("'foo' in obj", "'__FOO__' in obj", {
+        rename: { foo: "__FOO__" },
+      });
+    });
+    it("does not rename non-literal property", () => {
+      compare("prop in obj", "prop in obj", {
+        rename: { prop: "__PROP__" },
+      });
+
+      compare("('prop' + '1') in obj", "('prop' + '1') in obj", {
+        rename: { prop: "__PROP__" },
+      });
+    });
+    it("does not rename numeric literal property", () => {
+      compare("42 in obj", "42 in obj", {
+        rename: { 42: "__FORTY_TWO__" },
+      });
+    });
+    it("renames multiple `in` expressions", () => {
+      compare(
+        "'foo' in obj && 'bar' in obj",
+        "'__FOO__' in obj && '__BAR__' in obj",
+        {
+          rename: { foo: "__FOO__", bar: "__BAR__" },
+        }
+      );
+    });
+    it("renames `in` when right-hand side contains property access", () => {
+      compare("'foo' in obj.bar", "'__FOO__' in obj.__BAR__", {
+        rename: { foo: "__FOO__", bar: "__BAR__" },
+      });
+    });
+    it("does not rename template literal property", () => {
+      compare("`foo` in obj", "`foo` in obj", {
+        rename: { foo: "__FOO__" },
+      });
+    });
+    it("renames nested `in` expressions", () => {
+      compare("'foo' in ('bar' in obj)", "'__FOO__' in ('__BAR__' in obj)", {
+        rename: { foo: "__FOO__", bar: "__BAR__" },
+      });
+    });
+  });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -229,9 +229,18 @@ describe("babel-plugin-transform-rename-properties", () => {
         rename: { foo: "__FOO__", bar: "__BAR__" },
       });
     });
-    it("does not rename template literal property", () => {
-      compare("`foo` in obj", "`foo` in obj", {
+    it("renames constant template literal property", () => {
+      compare("`foo` in obj", "`__FOO__` in obj", {
         rename: { foo: "__FOO__" },
+      });
+    });
+    it("does not rename non-constant template literal property", () => {
+      compare("`${prop}` in obj", "`${prop}` in obj", {
+        rename: { prop: "__PROP__" },
+      });
+
+      compare("`prop${prop}` in obj", "`prop${prop}` in obj", {
+        rename: { prop: "__PROP__" },
       });
     });
     it("renames nested `in` expressions", () => {


### PR DESCRIPTION
Adds a BinaryExpression visitor that renames string literal properties used with the `in` operator (e.g., `'foo' in obj` → `'__FOO__' in obj`).

This change aims to match Terser's behavior here. Put the following options and example code in the [Terser REPL](https://try.terser.org/) to see it's behavior.

**Options**

```js
// edit terser options
{
  module: true,
  compress: {},
  mangle: {
    properties: {
      regex: "^_[^_]"
    }
  },
  output: {},
  parse: {},
  rename: {},
  nameCache: {
    props: {
      "cname": 6,
      "props": {
        "$_prop1": "p1"
      }
    }
  }
}
```

**Input**

```js
export const obj = {};

// Does transform
console.log("_prop1" in obj);
console.log('_prop1' in obj);
console.log(`_prop1` in obj);

// Does not transform
const s = "_prop1";
console.log(s); // Note: it will transform if you remove this line as it'll inline `s`
console.log(s in obj);
console.log("_prop2" in obj);

```

**Expected Output**

Note: newlines added by me for easier reading.

```js
export const obj={};
console.log("p1"in obj),
console.log("p1"in obj),
console.log("p1"in obj);

const o="_prop1";
console.log(o),
console.log(o in obj),
console.log("o"in obj);
```